### PR TITLE
add rpyc

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,4 @@ xformers >= 0.0.21
 fastapi
 uvicorn
 pydantic < 2  # Required for OpenAI server.
-rpyc >= 5.3.0  # try out rpyc TODO
+rpyc >= 5.3.0  # Required if you want to use RPyC. As of 5.3.0, there needs to be a separate change in the source to enable not-terrible performance compared to Ray.

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,3 +11,4 @@ xformers >= 0.0.21
 fastapi
 uvicorn
 pydantic < 2  # Required for OpenAI server.
+rpyc >= 5.3.0  # try out rpyc TODO

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1,4 +1,5 @@
 from typing import Optional
+
 import torch
 from transformers import PretrainedConfig
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -238,13 +238,15 @@ class ParallelConfig:
         pipeline_parallel_size: int,
         tensor_parallel_size: int,
         worker_use_ray: bool,
+        worker_use_rpyc: bool,
     ) -> None:
         self.pipeline_parallel_size = pipeline_parallel_size
         self.tensor_parallel_size = tensor_parallel_size
         self.worker_use_ray = worker_use_ray
+        self.worker_use_rpyc = worker_use_rpyc
 
         self.world_size = pipeline_parallel_size * tensor_parallel_size
-        if self.world_size > 1:
+        if self.world_size > 1 and not worker_use_rpyc:  # TODO messy handling of ray/rpyc
             self.worker_use_ray = True
         self._verify_args()
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1,6 +1,11 @@
 from typing import Optional
-
+import time
+import os
+print(">>>importing torch from vllmconfig", time.time(), os.getpid())
+# print("cuda visible devices?", os.environ.get("CUDA_VISIBLE_DEVICES"))
+# print("os.environ", os.environ)
 import torch
+print(">>>done importing torch", time.time(), os.getpid())
 from transformers import PretrainedConfig
 
 from vllm.logger import init_logger

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1,6 +1,4 @@
 from typing import Optional
-import time
-import os
 import torch
 from transformers import PretrainedConfig
 
@@ -247,7 +245,8 @@ class ParallelConfig:
         self.worker_use_rpyc = worker_use_rpyc
 
         self.world_size = pipeline_parallel_size * tensor_parallel_size
-        if self.world_size > 1 and not worker_use_rpyc:  # TODO messy handling of ray/rpyc
+        if self.world_size > 1 and not worker_use_rpyc:  
+            # HACK: kinda messy handling of whether we choose to use ray/rpyc/none for the workers
             self.worker_use_ray = True
         self._verify_args()
 

--- a/vllm/config.py
+++ b/vllm/config.py
@@ -1,11 +1,7 @@
 from typing import Optional
 import time
 import os
-print(">>>importing torch from vllmconfig", time.time(), os.getpid())
-# print("cuda visible devices?", os.environ.get("CUDA_VISIBLE_DEVICES"))
-# print("os.environ", os.environ)
 import torch
-print(">>>done importing torch", time.time(), os.getpid())
 from transformers import PretrainedConfig
 
 from vllm.logger import init_logger

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -20,6 +20,7 @@ class EngineArgs:
     seed: int = 0
     max_model_len: Optional[int] = None
     worker_use_ray: bool = False
+    worker_use_rpyc: bool = False
     pipeline_parallel_size: int = 1
     tensor_parallel_size: int = 1
     block_size: int = 16
@@ -110,6 +111,7 @@ class EngineArgs:
                             action='store_true',
                             help='use Ray for distributed serving, will be '
                             'automatically set when using more than 1 GPU')
+        parser.add_argument('--worker-use-rpyc', action='store_true', help='use rpyc for distributed serving, todo this is kinda hacked in')
         parser.add_argument('--pipeline-parallel-size',
                             '-pp',
                             type=int,
@@ -182,7 +184,8 @@ class EngineArgs:
                                    self.swap_space)
         parallel_config = ParallelConfig(self.pipeline_parallel_size,
                                          self.tensor_parallel_size,
-                                         self.worker_use_ray)
+                                         self.worker_use_ray,
+                                         self.worker_use_rpyc)
         scheduler_config = SchedulerConfig(self.max_num_batched_tokens,
                                            self.max_num_seqs,
                                            model_config.get_max_model_len())
@@ -193,6 +196,7 @@ class EngineArgs:
 class AsyncEngineArgs(EngineArgs):
     """Arguments for asynchronous vLLM engine."""
     engine_use_ray: bool = False
+    engine_use_rpyc: bool = False
     disable_log_requests: bool = False
     max_log_len: Optional[int] = None
 
@@ -204,6 +208,7 @@ class AsyncEngineArgs(EngineArgs):
                             action='store_true',
                             help='use Ray to start the LLM engine in a '
                             'separate process as the server process.')
+        parser.add_argument('--engine-use-rpyc', action='store_true', help='use rpyc to start the LLM engine in a separate process as the server process.')
         parser.add_argument('--disable-log-requests',
                             action='store_true',
                             help='disable logging requests')

--- a/vllm/engine/arg_utils.py
+++ b/vllm/engine/arg_utils.py
@@ -196,7 +196,6 @@ class EngineArgs:
 class AsyncEngineArgs(EngineArgs):
     """Arguments for asynchronous vLLM engine."""
     engine_use_ray: bool = False
-    engine_use_rpyc: bool = False
     disable_log_requests: bool = False
     max_log_len: Optional[int] = None
 
@@ -208,7 +207,6 @@ class AsyncEngineArgs(EngineArgs):
                             action='store_true',
                             help='use Ray to start the LLM engine in a '
                             'separate process as the server process.')
-        parser.add_argument('--engine-use-rpyc', action='store_true', help='use rpyc to start the LLM engine in a separate process as the server process.')
         parser.add_argument('--disable-log-requests',
                             action='store_true',
                             help='disable logging requests')

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -229,7 +229,8 @@ class _AsyncLLMEngine(LLMEngine):
             if not self.parallel_config.worker_use_rpyc or not rpyc_use_tpe:
                 output = executor(*args, **kwargs)
                 all_outputs.append(output)
-
+        m1 = time.time()
+        print(f"_run_workers_async prep executors {m1}")
         if self.parallel_config.worker_use_ray:
             all_outputs = await asyncio.gather(*all_outputs)
         elif self.parallel_config.worker_use_rpyc:
@@ -242,7 +243,8 @@ class _AsyncLLMEngine(LLMEngine):
                 # print(type(all_outputs))
                 # print(type(all_outputs[0]))
 
-
+        m2 = time.time()
+        print(f"_run_workers_async wait for gather, {m2}")
         if get_all_outputs:
             return all_outputs
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -211,7 +211,7 @@ class _AsyncLLMEngine(LLMEngine):
         **kwargs,
     ) -> Any:
         """Runs the given method on all workers."""
-        # print(f"_run_workers_async start {time.time()}")
+        print(f"_run_workers_async start {time.time()}")
         all_outputs = []
         for worker in self.workers:
             if self.parallel_config.worker_use_ray:
@@ -250,7 +250,7 @@ class _AsyncLLMEngine(LLMEngine):
             # if we're using rpyc, we are returned coroutines, and we can't assert equality
             for other_output in all_outputs[1:]:
                 assert output == other_output
-        # print(f"_run_workers_async end {time.time()}")
+        print(f"_run_workers_async end {time.time()}")
         return output
 
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -211,7 +211,7 @@ class _AsyncLLMEngine(LLMEngine):
         **kwargs,
     ) -> Any:
         """Runs the given method on all workers."""
-        print(f"_run_workers_async start {time.time()}")
+        # print(f"_run_workers_async start {time.time()}")
         all_outputs = []
         for worker in self.workers:
             if self.parallel_config.worker_use_ray:
@@ -250,7 +250,7 @@ class _AsyncLLMEngine(LLMEngine):
             # if we're using rpyc, we are returned coroutines, and we can't assert equality
             for other_output in all_outputs[1:]:
                 assert output == other_output
-        print(f"_run_workers_async end {time.time()}")
+        # print(f"_run_workers_async end {time.time()}")
         return output
 
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -219,7 +219,7 @@ class _AsyncLLMEngine(LLMEngine):
 
             output = executor(*args, **kwargs)
             all_outputs.append(output)
-        
+
         if self.parallel_config.worker_use_ray:
             all_outputs = await asyncio.gather(*all_outputs)
         elif self.parallel_config.worker_use_rpyc:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -227,7 +227,7 @@ class _AsyncLLMEngine(LLMEngine):
             return all_outputs
 
         # Make sure all workers have the same results.
-        print(all_outputs)
+        # print(all_outputs)
         # import pdb; pdb.set_trace()
         output = all_outputs[0]  # some "ray objectref" object in ray mode, some list(list(sequence_output)) in one-process mode
         if not self.parallel_config.worker_use_rpyc:

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -211,7 +211,8 @@ class _AsyncLLMEngine(LLMEngine):
         **kwargs,
     ) -> Any:
         """Runs the given method on all workers."""
-        print(f"_run_workers_async start {time.time()}")
+        st = time.time()
+        print(f"_run_workers_async start {st}")
         all_outputs = []
         for worker in self.workers:
             if self.parallel_config.worker_use_ray:
@@ -250,7 +251,9 @@ class _AsyncLLMEngine(LLMEngine):
             # if we're using rpyc, we are returned coroutines, and we can't assert equality
             for other_output in all_outputs[1:]:
                 assert output == other_output
-        print(f"_run_workers_async end {time.time()}")
+        en = time.time()
+        print(f"_run_workers_async end {en}")
+        print(f"_run_workers_async total {en - st}")
         return output
 
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -192,6 +192,7 @@ class _AsyncLLMEngine(LLMEngine):
             return ignored
 
         # Execute the model.
+        # TODO how big are the args even?
         output = await self._run_workers_async(
             "execute_model",
             seq_group_metadata_list=seq_group_metadata_list,

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -232,7 +232,7 @@ class _AsyncLLMEngine(LLMEngine):
             # outputs = await asyncio.gather(*all_outputs)
 
             
-            with ThreadPoolExecutor(max_workers=self.parallel_config.world_size) as tpe:
+            with ThreadPoolExecutor(max_workers=self.parallel_config.world_size) as tpe:  # increasing max_workers to 4 * worldsize doesn't seem to help
                 all_outputs = list(tpe.map(lambda worker: worker.execute_method(method, *args, **kwargs), self.workers))
                 # print(type(all_outputs))
                 # print(type(all_outputs[0]))

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -207,13 +207,11 @@ class _AsyncLLMEngine(LLMEngine):
     ) -> Any:
         """Runs the given method on all workers."""
         all_outputs = []
-
         for worker in self.workers:
             if self.parallel_config.worker_use_ray:
                 executor = partial(worker.execute_method.remote, method)
             elif self.parallel_config.worker_use_rpyc:
                 executor = partial(worker.aexecute_method, method)
-                pass
             else:
                 executor = getattr(worker, method)
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -228,10 +228,12 @@ class _AsyncLLMEngine(LLMEngine):
 
         # Make sure all workers have the same results.
         print(all_outputs)
-        import pdb; pdb.set_trace()
+        # import pdb; pdb.set_trace()
         output = all_outputs[0]  # some "ray objectref" object in ray mode, some list(list(sequence_output)) in one-process mode
-        for other_output in all_outputs[1:]:
-            assert output == other_output
+        if not self.parallel_config.worker_use_rpyc:
+            # if we're using rpyc, we are returned coroutines, and we can't assert equality
+            for other_output in all_outputs[1:]:
+                assert output == other_output
         return output
 
 

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -257,6 +257,7 @@ class AsyncLLMEngine:
 
     def __init__(self,
                  worker_use_ray: bool,
+                 worker_use_rpyc: bool,
                  engine_use_ray: bool,
                  engine_use_rpyc: bool,
                  *args,
@@ -267,6 +268,7 @@ class AsyncLLMEngine:
         assert not (engine_use_ray and engine_use_rpyc), (
             "Only one of engine_use_ray and engine_use_rpyc can be True.")
         self.worker_use_ray = worker_use_ray
+        self.worker_use_rpyc = worker_use_rpyc
         self.engine_use_ray = engine_use_ray
         self.engine_use_rpyc = engine_use_rpyc
         self.log_requests = log_requests

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -306,6 +306,9 @@ class AsyncLLMEngine:
         if not self.engine_use_ray and not self.engine_use_rpyc:
             engine_class = self._engine_class
         elif self.engine_use_rpyc:
+            # import pdb; pdb.set_trace()
+            print("wtf")
+            # What does engine_use_ray even do? do we need a separate 
             raise NotImplementedError("RPyC is not supported yet.")
         elif self.worker_use_ray:
             engine_class = ray.remote(num_cpus=0)(self._engine_class).remote
@@ -494,12 +497,14 @@ class AsyncLLMEngine:
         """Creates an async LLM engine from the engine arguments."""
         # Create the engine configs.
         engine_configs = engine_args.create_engine_configs()
+        print(engine_args)
         parallel_config = engine_configs[2]
         # Initialize the cluster.
         distributed_init_method, placement_group = initialize_cluster(
             parallel_config, engine_args.engine_use_ray)
         # Create the async LLM engine.
         engine = cls(engine_args.worker_use_ray,
+                     engine_args.worker_use_rpyc,
                      engine_args.engine_use_ray,
                      engine_args.engine_use_rpyc,
                      *engine_configs,

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -4,6 +4,8 @@ from functools import partial
 from typing import (Any, Dict, Iterable, List, Optional, Set, Tuple, Type,
                     Union)
 
+from concurrent.futures import ThreadPoolExecutor
+
 from vllm.config import ModelConfig
 from vllm.engine.arg_utils import AsyncEngineArgs
 from vllm.engine.llm_engine import LLMEngine
@@ -11,6 +13,8 @@ from vllm.engine.ray_utils import initialize_cluster, ray
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams
+
+import time
 
 logger = init_logger(__name__)
 
@@ -206,22 +210,33 @@ class _AsyncLLMEngine(LLMEngine):
         **kwargs,
     ) -> Any:
         """Runs the given method on all workers."""
+        print(f"_run_workers_async start {time.time()}")
         all_outputs = []
         for worker in self.workers:
             if self.parallel_config.worker_use_ray:
                 executor = partial(worker.execute_method.remote, method)
             elif self.parallel_config.worker_use_rpyc:
-                executor = partial(worker.aexecute_method, method)
+                # executor = partial(worker.aexecute_method, method)
+                pass
             else:
                 executor = getattr(worker, method)
 
-            output = executor(*args, **kwargs)
-            all_outputs.append(output)
+            if not self.parallel_config.worker_use_rpyc:
+                output = executor(*args, **kwargs)
+                all_outputs.append(output)
 
         if self.parallel_config.worker_use_ray:
             all_outputs = await asyncio.gather(*all_outputs)
         elif self.parallel_config.worker_use_rpyc:
-            all_outputs = await asyncio.gather(*all_outputs)
+            
+            # outputs = await asyncio.gather(*all_outputs)
+
+            
+            with ThreadPoolExecutor(max_workers=self.parallel_config.world_size) as tpe:
+                all_outputs = list(tpe.map(lambda worker: worker.execute_method(method, *args, **kwargs), self.workers))
+                # print(type(all_outputs))
+                # print(type(all_outputs[0]))
+
 
         if get_all_outputs:
             return all_outputs
@@ -234,6 +249,7 @@ class _AsyncLLMEngine(LLMEngine):
             # if we're using rpyc, we are returned coroutines, and we can't assert equality
             for other_output in all_outputs[1:]:
                 assert output == other_output
+        print(f"_run_workers_async end {time.time()}")
         return output
 
 
@@ -275,6 +291,8 @@ class AsyncLLMEngine:
                  **kwargs) -> None:
         assert not (engine_use_ray and engine_use_rpyc), (
             "Only one of engine_use_ray and engine_use_rpyc can be True.")
+        # TODO something similar with worker_use_ray + worker_use_rpyc probably
+        print(f">>> engine use ray: {engine_use_ray}, worker use ray/rpyc/none: {'ray' if worker_use_ray else 'rpyc' if worker_use_rpyc else 'none'}")
         self.worker_use_ray = worker_use_ray
         self.worker_use_rpyc = worker_use_rpyc
         self.engine_use_ray = engine_use_ray

--- a/vllm/engine/async_llm_engine.py
+++ b/vllm/engine/async_llm_engine.py
@@ -219,6 +219,7 @@ class _AsyncLLMEngine(LLMEngine):
 
             output = executor(*args, **kwargs)
             all_outputs.append(output)
+        
         if self.parallel_config.worker_use_ray:
             all_outputs = await asyncio.gather(*all_outputs)
         elif self.parallel_config.worker_use_rpyc:

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -297,7 +297,7 @@ class LLMEngine:
             
 
 
-        raise NotImplementedError("rpyc not implemented yet")
+        # raise NotImplementedError("rpyc not implemented yet")
 
     def _verify_args(self) -> None:
         self.model_config.verify_with_parallel_config(self.parallel_config)

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1,7 +1,6 @@
 import copy
 import time
 from functools import partial
-import asyncio as aio
 from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, Union
 
 from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
@@ -197,6 +196,8 @@ class LLMEngine:
         from multiprocessing import Process, set_start_method
         import rpyc
         from vllm.worker.worker import Worker  # pylint: disable=import-outside-toplevel
+
+        import asyncio as aio  # todo doesn't break ray
 
         self.workers: List[RPyCWorkerClient] = []  # TODO type
         set_start_method("spawn")

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -8,6 +8,7 @@ from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
 from vllm.core.scheduler import Scheduler, SchedulerOutputs
 from vllm.engine.arg_utils import EngineArgs
 from vllm.engine.ray_utils import RayWorker, initialize_cluster, ray
+from vllm.engine.rpyc_utils import init_rpyc_env
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams
@@ -189,6 +190,21 @@ class LLMEngine:
 
         # uh probably create a Worker on each process, behind a rpyc server-thing that exposes the Worker's methods
         # and call the _run_workers init_worker + init_model probably idk
+
+        from multiprocessing import Process
+        import rpyc
+
+        self.workers = []  # TODO type
+        for i in range(self.parallel_config.world_size):
+            # TODO spawn a process with a Worker and rpyc server, stick it in the mp
+            port = 1234 # TODO obvs don't just default it
+            p = Process(target=init_rpyc_env, args=(port,))
+            p.start()
+            con = rpyc.connect("localhost", port, config={"allow_pickle": True})  # todo lightllm has retries here, you probably want to as well
+
+            
+            pass
+
 
         raise NotImplementedError("rpyc not implemented yet")
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -252,6 +252,7 @@ class LLMEngine:
         # Initialize torch distributed process group for the workers.
 
         addr, port = self.workers[0].get_addr_and_port()
+        print(f"addr {addr} port {port}")
 
         executors = []
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -188,8 +188,6 @@ class LLMEngine:
         import rpyc
         from vllm.worker.worker import Worker  # pylint: disable=import-outside-toplevel
 
-        import asyncio as aio
-
         from vllm.engine.rpyc_utils import RPyCWorkerClient, init_rpyc_env, find_free_port  # Import here, otherwise we break Ray
 
         self.workers: List[RPyCWorkerClient] = []

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -226,12 +226,9 @@ class LLMEngine:
 
         # Initialize torch distributed process group for the workers.
         addr, port = self.workers[0].get_addr_and_port()
-        print(f"addr {addr} port {port}")
 
         executors = []
-
         for i, worker_client in enumerate(self.workers):
-            worker_client.print_debug_msg(str(i))
             exec = worker_client.ainit_torch_distributed(
                 addr,
                 port,
@@ -244,14 +241,12 @@ class LLMEngine:
         loop.run_until_complete(aio.gather(*executors))
 
         executors = []
-
         for worker_client in self.workers:
             exec = worker_client.ainit_worker(
                 self.model_config, self.parallel_config, self.scheduler_config
             )
             executors.append(exec)
         loop.run_until_complete(aio.gather(*executors))
-        print("attempting to init model")
         self._run_workers(
             "init_model",
             get_all_outputs=True,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -206,7 +206,7 @@ class LLMEngine:
         ports = []
         set_start_method("spawn")
         for i in range(self.parallel_config.world_size):
-            print(f"spawning child process {i}")
+            print(f">>> spawning child process {i}")
             # TODO spawn a process with a Worker and rpyc server, stick it in the mp
             port = find_free_port() # TODO obvs don't just default it
             # import pdb; pdb.set_trace()
@@ -229,7 +229,7 @@ class LLMEngine:
             else:
                 raise ConnectionRefusedError("couldn't connect to workers")
 
-        print("got to initializing workers")
+        print(">>> got to initializing workers")
         # Initialize torch distributed process group for the workers.
 
         addr, port = self.workers[0].get_addr_and_port()
@@ -237,7 +237,7 @@ class LLMEngine:
         executors = []
 
         for i, worker_client in enumerate(self.workers):
-            print(f"printing for process {i}")
+            print(f">>> printing for process {i}")
             worker_client.print_debug_msg(str(i))
             exec = worker_client.ainit_torch_distributed(
                 addr,  # TODO
@@ -250,7 +250,7 @@ class LLMEngine:
         loop = aio.get_event_loop()
         loop.run_until_complete(aio.gather(*executors))  # TODO may have to replace aio.run with something else because of some "no current event loop" thing
 
-        print("initialized torchdist")
+        print(">>> initialized torchdist")
         for worker_client in self.workers:
             worker_client.init_worker(
                 self.model_config, self.parallel_config, self.scheduler_config

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -8,7 +8,7 @@ from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
 from vllm.core.scheduler import Scheduler, SchedulerOutputs
 from vllm.engine.arg_utils import EngineArgs
 from vllm.engine.ray_utils import RayWorker, initialize_cluster, ray
-from vllm.engine.rpyc_utils import RPyCWorkerClient, init_rpyc_env
+
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams
@@ -198,6 +198,8 @@ class LLMEngine:
         from vllm.worker.worker import Worker  # pylint: disable=import-outside-toplevel
 
         import asyncio as aio  # todo doesn't break ray
+
+        from vllm.engine.rpyc_utils import RPyCWorkerClient, init_rpyc_env  # todo does moving this here cause ray to not break yup
 
         self.workers: List[RPyCWorkerClient] = []  # TODO type
         set_start_method("spawn")

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -146,7 +146,7 @@ class LLMEngine:
         # before CUDA_VISIBLE_DEVICES is set in the Worker
         from vllm.worker.worker import Worker  # pylint: disable=import-outside-toplevel
 
-        # note (TODO delete) I'm assuming this process 
+        # note (TODO delete) I'm assuming this process launches the workers 
 
         self.workers: List[Worker] = []
         for bundle in placement_group.bundle_specs:  # probably creates N workers or something idk

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -806,14 +806,15 @@ class LLMEngine:
             if self.parallel_config.worker_use_ray:
                 executor = partial(worker.execute_method.remote, method)
             elif self.parallel_config.worker_use_rpyc:
-                # executor = partial(worker.aexecute_method, method)
+                executor = partial(worker.aexecute_method, method)
                 # executor = partial(worker.execute_method, method)
                 pass
             else:
                 executor = getattr(worker, method)
 
-            if not self.parallel_config.worker_use_rpyc:
-                # If we're using rpyc, call the fns later
+            rpyc_use_tpe = False
+            if not self.parallel_config.worker_use_rpyc or not rpyc_use_tpe:
+                # If we're using rpyc, call the fns later if we're using thread pool executor
                 output = executor(*args, **kwargs)
                 all_outputs.append(output)
 
@@ -823,14 +824,14 @@ class LLMEngine:
             # idk is it this? probably
             # TODO I think there's a bug in here where we need to spam the requests out as fast as possible
             # but we don't
-            # import asyncio as aio  # TODO move to top
-            # loop = aio.get_event_loop()
-            # all_outputs = loop.run_until_complete(aio.gather(*all_outputs))
+            import asyncio as aio  # TODO move to top
+            loop = aio.get_event_loop()
+            all_outputs = loop.run_until_complete(aio.gather(*all_outputs))
 
             # TODO try multithreading/processing instead
-            from concurrent.futures import ThreadPoolExecutor  # TODO move import up
-            with ThreadPoolExecutor(max_workers=self.parallel_config.world_size) as tpe:
-                all_outputs = list(tpe.map(lambda worker: worker.execute_method(method, *args, **kwargs), self.workers))
+            # from concurrent.futures import ThreadPoolExecutor  # TODO move import up
+            # with ThreadPoolExecutor(max_workers=self.parallel_config.world_size) as tpe:
+            #     all_outputs = list(tpe.map(lambda worker: worker.execute_method(method, *args, **kwargs), self.workers))
                 # print(type(all_outputs))
                 # print(type(all_outputs[0]))
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -203,12 +203,12 @@ class LLMEngine:
         for i in range(self.parallel_config.world_size):
             print(f"spawning child process {i}")
             # TODO spawn a process with a Worker and rpyc server, stick it in the mp
-            port = 12345 + i # TODO obvs don't just default it
+            port = 32415 + i # TODO obvs don't just default it
             p = Process(target=init_rpyc_env, args=(port,))
             p.start()
         aio.run(aio.sleep(2))
         for i in range(self.parallel_config.world_size):
-            port = 12345 + i
+            port = 32415 + i
             for _ in range(20):
                 try:
                     conn = rpyc.connect("localhost", port, config={"allow_pickle": True})  # todo lightllm has retries here, you probably want to as well
@@ -228,7 +228,7 @@ class LLMEngine:
             worker_client.print_debug_msg(str(i))
             worker_client.init_torch_distributed(
                 "localhost",  # TODO
-                12345,  # TODO
+                32415,  # TODO
                 list(range(self.parallel_config.world_size)),  # TODO
                 self.parallel_config.world_size,
                 i,

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -10,7 +10,6 @@ from vllm.config import (CacheConfig, ModelConfig, ParallelConfig,
 from vllm.core.scheduler import Scheduler, SchedulerOutputs
 from vllm.engine.arg_utils import EngineArgs
 from vllm.engine.ray_utils import RayWorker, initialize_cluster, ray
-
 from vllm.logger import init_logger
 from vllm.outputs import RequestOutput
 from vllm.sampling_params import SamplingParams
@@ -24,7 +23,6 @@ from vllm.utils import Counter
 if ray:
     from ray.air.util.torch_dist import init_torch_dist_process_group
     from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
-
 
 if TYPE_CHECKING:
     from ray.util.placement_group import PlacementGroup

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -102,7 +102,7 @@ class LLMEngine:
         if self.parallel_config.worker_use_ray:
             self._init_workers_ray(placement_group)
         elif self.parallel_config.worker_use_rpyc:
-            self.init_workers_rpyc("todo")
+            self._init_workers_rpyc("todo")
         else:
             self._init_workers(distributed_init_method)
 

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -1,6 +1,7 @@
 import copy
 import time
 import os
+import asyncio as aio
 from functools import partial
 from typing import TYPE_CHECKING, Any, Iterable, List, Optional, Tuple, Union
 
@@ -758,38 +759,22 @@ class LLMEngine:
         """Runs the given method on all workers."""
         all_outputs = []
         for worker in self.workers:
-            # TODO clean up code
             if self.parallel_config.worker_use_ray:
                 executor = partial(worker.execute_method.remote, method)
             elif self.parallel_config.worker_use_rpyc:
                 executor = partial(worker.aexecute_method, method)
-                # executor = partial(worker.execute_method, method)
-                pass
             else:
                 executor = getattr(worker, method)
 
-            rpyc_use_tpe = False
-            if not self.parallel_config.worker_use_rpyc or not rpyc_use_tpe:
-                # If we're using rpyc, call the fns later if we're using thread pool executor
-                output = executor(*args, **kwargs)
-                all_outputs.append(output)
+            output = executor(*args, **kwargs)
+            all_outputs.append(output)
 
         if self.parallel_config.worker_use_ray:
             all_outputs = ray.get(all_outputs)
         elif self.parallel_config.worker_use_rpyc:
-            # idk is it this? probably
-            # TODO I think there's a bug in here where we need to spam the requests out as fast as possible
-            # but we don't
-            import asyncio as aio  # TODO move to top
+            # There may be a faster way to make all the requests.
             loop = aio.get_event_loop()
             all_outputs = loop.run_until_complete(aio.gather(*all_outputs))
-
-            # TODO try multithreading/processing instead
-            # from concurrent.futures import ThreadPoolExecutor  # TODO move import up
-            # with ThreadPoolExecutor(max_workers=self.parallel_config.world_size) as tpe:
-            #     all_outputs = list(tpe.map(lambda worker: worker.execute_method(method, *args, **kwargs), self.workers))
-                # print(type(all_outputs))
-                # print(type(all_outputs[0]))
 
         if get_all_outputs:
             return all_outputs

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -101,9 +101,10 @@ class LLMEngine:
         # Create the parallel GPU workers.
         if self.parallel_config.worker_use_ray:
             self._init_workers_ray(placement_group)
+        elif self.parallel_config.worker_use_rpyc:
+            self.init_workers_rpyc("todo")
         else:
             self._init_workers(distributed_init_method)
-        # TODO self._init_workers_rpyc
 
         # Profile the memory usage and initialize the cache.
         self._init_cache()
@@ -185,7 +186,7 @@ class LLMEngine:
         # set rank/url/port/etc. for rpyc workers
         # use mp to run the workers
         # note: parallel_config controls whether we're using ray or not
-        pass
+        raise NotImplementedError("rpyc not implemented yet")
 
     def _verify_args(self) -> None:
         self.model_config.verify_with_parallel_config(self.parallel_config)

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -186,6 +186,10 @@ class LLMEngine:
         # set rank/url/port/etc. for rpyc workers
         # use mp to run the workers
         # note: parallel_config controls whether we're using ray or not
+
+        # uh probably create a Worker on each process, behind a rpyc server-thing that exposes the Worker's methods
+        # and call the _run_workers init_worker + init_model probably idk
+
         raise NotImplementedError("rpyc not implemented yet")
 
     def _verify_args(self) -> None:
@@ -692,6 +696,8 @@ class LLMEngine:
         for worker in self.workers:
             if self.parallel_config.worker_use_ray:
                 executor = partial(worker.execute_method.remote, method)
+            elif self.parallel_config.worker_use_rpyc:
+                raise NotImplementedError("rpyc not implemented yet")
             else:
                 executor = getattr(worker, method)
 
@@ -700,6 +706,8 @@ class LLMEngine:
 
         if self.parallel_config.worker_use_ray:
             all_outputs = ray.get(all_outputs)
+        elif self.parallel_config.worker_use_rpyc:
+            raise NotImplementedError("rpyc not implemented yet")
 
         if get_all_outputs:
             return all_outputs

--- a/vllm/engine/llm_engine.py
+++ b/vllm/engine/llm_engine.py
@@ -23,6 +23,7 @@ if ray:
     from ray.air.util.torch_dist import init_torch_dist_process_group
     from ray.util.scheduling_strategies import PlacementGroupSchedulingStrategy
 
+
 if TYPE_CHECKING:
     from ray.util.placement_group import PlacementGroup
 

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -4,21 +4,26 @@ import os
 import asyncio as aio
 import rpyc
 from rpyc.utils.server import ThreadedServer
+from rpyc.utils.classic import obtain
+
+from vllm.worker.worker import Worker
 
 class RPyCWorkerService(rpyc.Service):
     def on_connect(self, conn):
+
         pass
 
     def on_disconnect(self, conn):
         pass
 
     def exposed_print_debug_msg(self, msg):
-        print(f"{os.getpid()}:{msg}")
+        print(f"in service {os.getpid()}:{msg}")
 
     def exposed_init_torch_distributed(self, master_addr, master_port, gpu_ids, world_size, rank):
         # https://github.com/ray-project/ray/blob/7a3ae5ba5dbd6704f435bde8dba91a8a8d207ae4/python/ray/air/util/torch_dist.py#L95
         # for reference
         print(f"Running on {os.getpid()}")
+        print(f"{master_addr}:{master_port}, #gpus {gpu_ids}, ws {world_size}, rank {rank}")
         
         os.environ["MASTER_ADDR"] = str(master_addr)  # idk lmao search up torch distributed
         os.environ["MASTER_PORT"] = str(master_port)
@@ -33,13 +38,27 @@ class RPyCWorkerService(rpyc.Service):
         os.environ["RANK"] = str(rank)
         os.environ["LOCAL_RANK"] = str(rank)
 
-    def exposed_init_worker(self, worker_init_fn):
-        print(f"Running on {os.getpid()}")
+    def exposed_init_worker_doesnt_work(self, worker_init_fn):
+        print(f"init_worker running on {os.getpid()}")
         # TODO check that worker_init_fn runs on the worker process
+        print(worker_init_fn, type(worker_init_fn))
         self.worker = worker_init_fn()
+        print(type(self.worker))
+        # dumb hack idk how to get the thing to initialize the worker here so will do it manually
+
+    def exposed_init_worker(self, model_config, parallel_config, scheduler_config):
+        print(f"in worker {os.getpid()}, {model_config}, {parallel_config}, {scheduler_config}")
+        self.worker = Worker(
+            model_config,
+            parallel_config,
+            scheduler_config,
+            None,
+            f"tcp://{os.environ['MASTER_ADDR']}:{os.environ['MASTER_PORT']}",  # TODO ????????? figure this out, goes into torch.dist.init_process_group whatever that does 
+        )
 
     def exposed_execute_method(self, method: str, *args, **kwargs):
-        print(f"Running on {os.getpid()}")
+        print(f"execute_method running on {os.getpid()}")
+        print(type(self.worker))
         executor = getattr(self.worker, method)
         return executor(*args, **kwargs)
     
@@ -61,6 +80,10 @@ class RPyCWorkerClient:
         self._init_torch_distributed = self.conn.root.init_torch_distributed
         self._init_worker = self.conn.root.init_worker
         self._execute_method = self.conn.root.execute_method
+        def obtain(*args, **kwargs):
+            new_args = obtain(args)
+            new_kwargs = obtain(kwargs)
+            return new_args, new_kwargs
 
 
     def print_debug_msg(self, msg):
@@ -74,10 +97,12 @@ class RPyCWorkerClient:
     def init_torch_distributed(self, master_addr, master_port, gpu_ids, world_size, rank):
         self._init_torch_distributed(master_addr, master_port, gpu_ids, world_size, rank)
 
-    def init_worker(self, worker_init_fn):
-        self._init_worker(worker_init_fn)
+    def init_worker(self, model_config, parallel_config, scheduler_config):
+        # TODO something to mark as transferable? idk lightllm does this
+        self._init_worker(model_config, parallel_config, scheduler_config)
 
     def execute_method(self, method, *args, **kwargs):
+        print(f"executing method {method}")
         return self._execute_method(method, *args, **kwargs)  # TODO is this right?
     
     async def aexecute_method(self, method, *args, **kwargs):
@@ -92,6 +117,7 @@ class RPyCWorkerClient:
 
 
 def init_rpyc_env(port):
+    print(f"init_rpyc_env for port {port}")
     t = ThreadedServer(RPyCWorkerService(), port=port, protocol_config={"allow_pickle": True})
     t.start()
     return

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -171,6 +171,8 @@ def init_rpyc_env(port):
     # We need to import torch here, otherwise torch won't recognize CUDA devices as available.
     # Not sure why unfortunately, but I think it's related to some ordering of imports/environment set up
     import torch
+    # This following print is necessary for the workers to start up, otherwise we get some 
+    print("init_rpyc_env cuda support:", torch.cuda.is_available(),":", torch.cuda.device_count(), "devices")
     t = ThreadedServer(RPyCWorkerService(), port=port, protocol_config={"allow_pickle": True})
     t.start()
     return

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -1,0 +1,48 @@
+# TODO maybe wrap in a try except ImportError? idk
+
+import os
+import rpyc
+from rpyc.utils.server import ThreadedServer
+
+class RPyCWorkerService(rpyc.Service):
+    def on_connect(self, conn):
+        pass
+
+    def on_disconnect(self, conn):
+        pass
+
+    def exposed_init_torch_distributed(self, master_addr, master_port, gpu_ids, world_size, rank):
+        # https://github.com/ray-project/ray/blob/7a3ae5ba5dbd6704f435bde8dba91a8a8d207ae4/python/ray/air/util/torch_dist.py#L95
+        # for reference
+        
+        os.environ["MASTER_ADDR"] = str(master_addr)  # idk lmao search up torch distributed
+        os.environ["MASTER_PORT"] = str(master_port)
+
+        os.environ["NCCL_ASYNC_ERROR_HANDLING"] = "1"  # idk what this does
+        os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(gpu_id for gpu_id in gpu_ids))
+
+
+        # running on one node, local_{rank|world_size} is same as {rank|world_size}
+        os.environ["WORLD_SIZE"] = str(world_size)
+        os.environ["LOCAL_WORLD_SIZE"] = str(world_size)
+        os.environ["RANK"] = str(rank)
+        os.environ["LOCAL_RANK"] = str(rank)
+
+    def exposed_init_worker(self, worker_init_fn):
+        self.worker = worker_init_fn()
+
+    def exposed_execute_method(self, method, *args, **kwargs):
+        executor = getattr(self, method)
+        return executor(*args, **kwargs)
+    
+class RPyCWorkerClient:
+    def __init__(self, conn):
+        self.conn = conn
+
+    def execute_method(self, method, *args, **kwargs):
+        return self.conn.root.execute_method(method, *args, **kwargs)  # TODO is this right?
+
+def init_rpyc_env(port):
+    t = ThreadedServer(RPyCWorkerService(), port=port, protocol_config={"allow_pickle": True})
+    t.start()
+    return

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -171,7 +171,8 @@ def init_rpyc_env(port):
     # We need to import torch here, otherwise torch won't recognize CUDA devices as available.
     # Not sure why unfortunately, but I think it's related to some ordering of imports/environment set up
     import torch
-    # This following print is necessary for the workers to start up, otherwise we get some 
+    # This following print is necessary for the workers to start up, otherwise we get some weird error with torch not recognizing gpus
+    # We probably just need to run `torch.cuda.is_available()/.device_count()`
     print("init_rpyc_env cuda support:", torch.cuda.is_available(),":", torch.cuda.device_count(), "devices")
     t = ThreadedServer(RPyCWorkerService(), port=port, protocol_config={"allow_pickle": True})
     t.start()

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -8,7 +8,7 @@ from rpyc.utils.classic import obtain
 import torch.distributed as dist
 from datetime import timedelta
 
-from vllm.worker.worker import Worker
+from vllm.worker.worker import Worker  # TODO this import breaks lmaooo
 
 class RPyCWorkerService(rpyc.Service):
     def on_connect(self, conn):

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -108,12 +108,12 @@ class RPyCWorkerService(rpyc.Service):
     def exposed_execute_method(self, method: str, *args, **kwargs):
         # print(f"execute_method running on {os.getpid()}")
         # raise ValueError("crashing to view call stack")
-        # print(os.getpid(), "starthead", time.time())
+        print(os.getpid(), "starthead", time.time())
         args, kwargs = obtain(args), obtain(kwargs)
         executor = getattr(self.worker, method)
-        # print(os.getpid(), "startexec", time.time())
+        print(os.getpid(), "startexec", time.time())
         retval = executor(*args, **kwargs)
-        # print(os.getpid(), "stopexec", time.time())
+        print(os.getpid(), "stopexec", time.time())
         return retval
     
 class RPyCWorkerClient:
@@ -164,9 +164,9 @@ class RPyCWorkerClient:
         self._init_worker(model_config, parallel_config, scheduler_config)
 
     def execute_method(self, method, *args, **kwargs):
-        # print(f"executing method {method} at {time.time()}")  # with threadpoolexecutor these prints seem to execute at the same time
+        print(f"executing method {method} at {time.time()}")  # with threadpoolexecutor these prints seem to execute at the same time
         ans = self._execute_method(method, *args, **kwargs)  # TODO is this right?
-        # print(f"finish executing method {method} at {time.time()}")
+        print(f"finish executing method {method} at {time.time()}")
         new_ans = obtain(ans)
         return new_ans
     
@@ -175,7 +175,7 @@ class RPyCWorkerClient:
     
     async def aexecute_method(self, method, *args, **kwargs):
         t1 = time.time()
-        # print(f'started at {t1}')
+        print(f'started at {t1}')
         ans = await self._aexecute_method(method, *args, **kwargs)
         # t2 = time.time()
         new_ans = obtain(ans)  # seems fast enough

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -109,7 +109,7 @@ class RPyCWorkerService(rpyc.Service):
         # print(f"execute_method running on {os.getpid()}")
         # raise ValueError("crashing to view call stack")
         print(os.getpid(), "starthead", time.time())
-        args, kwargs = obtain(args), obtain(kwargs)
+        args, kwargs = obtain(args), obtain(kwargs)  # is this thing slow?
         executor = getattr(self.worker, method)
         print(os.getpid(), "startexec", time.time())
         retval = executor(*args, **kwargs)

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -119,6 +119,7 @@ class RPyCWorkerService(rpyc.Service):
 class RPyCWorkerClient:
     def __init__(self, conn):
         self.conn = conn
+        print("workerclient.conn type", type(self.conn))
         def async_wrap(f):
             f = rpyc.async_(f)
             async def _func(*args, **kwargs):

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -108,12 +108,12 @@ class RPyCWorkerService(rpyc.Service):
     def exposed_execute_method(self, method: str, *args, **kwargs):
         # print(f"execute_method running on {os.getpid()}")
         # raise ValueError("crashing to view call stack")
-        print(os.getpid(), "starthead", time.time())
+        # print(os.getpid(), "starthead", time.time())
         args, kwargs = obtain(args), obtain(kwargs)  # is this thing slow?
         executor = getattr(self.worker, method)
-        print(os.getpid(), "startexec", time.time())
+        # print(os.getpid(), "startexec", time.time())
         retval = executor(*args, **kwargs)
-        print(os.getpid(), "stopexec", time.time())
+        # print(os.getpid(), "stopexec", time.time())
         return retval
     
 class RPyCWorkerClient:
@@ -175,7 +175,7 @@ class RPyCWorkerClient:
     
     async def aexecute_method(self, method, *args, **kwargs):
         t1 = time.time()
-        print(f'started at {t1}')
+        # print(f'started at {t1}')
         ans = await self._aexecute_method(method, *args, **kwargs)
         # t2 = time.time()
         new_ans = obtain(ans)  # seems fast enough

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -168,8 +168,8 @@ class RPyCWorkerClient:
     async def ainit_torch_distributed(self, master_addr, master_port, gpu_ids, world_size, rank):
         return await self._ainit_torch_distributed(master_addr, master_port, gpu_ids, world_size, rank)
     
-    async def ainit_worker(self, worker_init_fn):
-        return await self._ainit_worker(worker_init_fn)
+    async def ainit_worker(self, model_config, parallel_config, scheduler_config):
+        return await self._ainit_worker(model_config, parallel_config, scheduler_config)
 
 
 

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -164,7 +164,8 @@ class RPyCWorkerClient:
         return self._get_addr_and_port()
     
     async def aexecute_method(self, method, *args, **kwargs):
-        return await self._aexecute_method(method, *args, **kwargs)
+        ans = await self._aexecute_method(method, *args, **kwargs)
+        return obtain(ans)  # do we need to check None? probably not?
     
     async def ainit_torch_distributed(self, master_addr, master_port, gpu_ids, world_size, rank):
         return await self._ainit_torch_distributed(master_addr, master_port, gpu_ids, world_size, rank)

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -177,8 +177,3 @@ def init_rpyc_env(port):
     t = ThreadedServer(RPyCWorkerService(), port=port, protocol_config={"allow_pickle": True})
     t.start()
     return
-
-def example(local_rank):
-    # debug torch cuda
-    import torch
-    print("Example Cuda support:", torch.cuda.is_available(),":", torch.cuda.device_count(), "devices")

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -5,6 +5,8 @@ import asyncio as aio
 import rpyc
 from rpyc.utils.server import ThreadedServer
 from rpyc.utils.classic import obtain
+import torch.distributed as dist
+from datetime import timedelta
 
 from vllm.worker.worker import Worker
 
@@ -30,7 +32,9 @@ class RPyCWorkerService(rpyc.Service):
 
         os.environ["NCCL_ASYNC_ERROR_HANDLING"] = "1"  # idk what this does
         os.environ["CUDA_VISIBLE_DEVICES"] = ",".join(str(gpu_id for gpu_id in gpu_ids))
-
+    
+        # ray makes a call to init process group here
+        dist.init_process_group(backend="nccl", init_method="env://", rank=rank, world_size=world_size, timeout=timedelta(seconds=1800))
 
         # running on one node, local_{rank|world_size} is same as {rank|world_size}
         os.environ["WORLD_SIZE"] = str(world_size)

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -102,7 +102,8 @@ class RPyCWorkerClient:
             f = rpyc.async_(f)
             async def _func(*args, **kwargs):
                 ans = f(*args, **kwargs)
-                ans.set_expiry(3600)  # absurdly long, wait for model to init
+                # ans.set_expiry(3600)  # absurdly long, wait for model to init
+                print(ans._ttl)
                 await aio.to_thread(ans.wait)
                 # raise if exception
                 return ans.value

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -11,9 +11,13 @@ class RPyCWorkerService(rpyc.Service):
     def on_disconnect(self, conn):
         pass
 
+    def exposed_print_debug_msg(self, msg):
+        print(f"{os.getpid()}:{msg}")
+
     def exposed_init_torch_distributed(self, master_addr, master_port, gpu_ids, world_size, rank):
         # https://github.com/ray-project/ray/blob/7a3ae5ba5dbd6704f435bde8dba91a8a8d207ae4/python/ray/air/util/torch_dist.py#L95
         # for reference
+        print(f"Running on {os.getpid()}")
         
         os.environ["MASTER_ADDR"] = str(master_addr)  # idk lmao search up torch distributed
         os.environ["MASTER_PORT"] = str(master_port)
@@ -29,18 +33,31 @@ class RPyCWorkerService(rpyc.Service):
         os.environ["LOCAL_RANK"] = str(rank)
 
     def exposed_init_worker(self, worker_init_fn):
+        print(f"Running on {os.getpid()}")
+        # TODO check that worker_init_fn runs on the worker process
         self.worker = worker_init_fn()
 
-    def exposed_execute_method(self, method, *args, **kwargs):
-        executor = getattr(self, method)
+    def exposed_execute_method(self, method: str, *args, **kwargs):
+        executor = getattr(self.worker, method)  # TODO f"exposed_{method}"?
         return executor(*args, **kwargs)
     
 class RPyCWorkerClient:
     def __init__(self, conn):
         self.conn = conn
 
+    def print_debug_msg(self, msg):
+        self.conn.root.print_debug_msg(msg)
+    
+    def init_torch_distributed(self, master_addr, master_port, gpu_ids, world_size, rank):
+        self.conn.root.init_torch_distributed(master_addr, master_port, gpu_ids, world_size, rank)
+
+    def init_worker(self, worker_init_fn):
+        self.conn.root.init_worker(worker_init_fn)
+
     def execute_method(self, method, *args, **kwargs):
         return self.conn.root.execute_method(method, *args, **kwargs)  # TODO is this right?
+
+
 
 def init_rpyc_env(port):
     t = ThreadedServer(RPyCWorkerService(), port=port, protocol_config={"allow_pickle": True})

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -107,7 +107,7 @@ class RPyCWorkerService(rpyc.Service):
 
     def exposed_execute_method(self, method: str, *args, **kwargs):
         # print(f"execute_method running on {os.getpid()}")
-        # print(type(self.worker))
+        # raise ValueError("crashing to view call stack")
         print(os.getpid(), "starthead", time.time())
         args, kwargs = obtain(args), obtain(kwargs)
         executor = getattr(self.worker, method)

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -108,12 +108,12 @@ class RPyCWorkerService(rpyc.Service):
     def exposed_execute_method(self, method: str, *args, **kwargs):
         # print(f"execute_method running on {os.getpid()}")
         # raise ValueError("crashing to view call stack")
-        print(os.getpid(), "starthead", time.time())
+        # print(os.getpid(), "starthead", time.time())
         args, kwargs = obtain(args), obtain(kwargs)
         executor = getattr(self.worker, method)
-        print(os.getpid(), "startexec", time.time())
+        # print(os.getpid(), "startexec", time.time())
         retval = executor(*args, **kwargs)
-        print(os.getpid(), "stopexec", time.time())
+        # print(os.getpid(), "stopexec", time.time())
         return retval
     
 class RPyCWorkerClient:
@@ -164,9 +164,9 @@ class RPyCWorkerClient:
         self._init_worker(model_config, parallel_config, scheduler_config)
 
     def execute_method(self, method, *args, **kwargs):
-        print(f"executing method {method} at {time.time()}")  # with threadpoolexecutor these prints seem to execute at the same time
+        # print(f"executing method {method} at {time.time()}")  # with threadpoolexecutor these prints seem to execute at the same time
         ans = self._execute_method(method, *args, **kwargs)  # TODO is this right?
-        print(f"finish executing method {method} at {time.time()}")
+        # print(f"finish executing method {method} at {time.time()}")
         new_ans = obtain(ans)
         return new_ans
     
@@ -175,7 +175,7 @@ class RPyCWorkerClient:
     
     async def aexecute_method(self, method, *args, **kwargs):
         t1 = time.time()
-        print(f'started at {t1}')
+        # print(f'started at {t1}')
         ans = await self._aexecute_method(method, *args, **kwargs)
         # t2 = time.time()
         new_ans = obtain(ans)  # seems fast enough

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -59,7 +59,7 @@ class RPyCWorkerService(rpyc.Service):
             parallel_config,
             scheduler_config,
             None,
-            f"tcp://{os.environ['MASTER_ADDR']}:{os.environ['MASTER_PORT']}",  # TODO ????????? figure this out, goes into torch.dist.init_process_group whatever that does 
+            "env://", # f"tcp://{os.environ['MASTER_ADDR']}:{os.environ['MASTER_PORT']}",  # TODO ????????? figure this out, goes into torch.dist.init_process_group whatever that does 
         )
 
     def exposed_execute_method(self, method: str, *args, **kwargs):

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -119,7 +119,9 @@ class RPyCWorkerService(rpyc.Service):
 class RPyCWorkerClient:
     def __init__(self, conn):
         self.conn = conn
-        print("workerclient.conn type", type(self.conn))
+        # conn is type rpyc.core.protocol.Connection
+        # import pdb; pdb.set_trace()
+        # print("workerclient.conn type", type(self.conn))  # apparently this hangs? wtf
         def async_wrap(f):
             f = rpyc.async_(f)
             async def _func(*args, **kwargs):

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -38,7 +38,8 @@ class RPyCWorkerService(rpyc.Service):
         self.worker = worker_init_fn()
 
     def exposed_execute_method(self, method: str, *args, **kwargs):
-        executor = getattr(self.worker, method)  # TODO f"exposed_{method}"?
+        print(f"Running on {os.getpid()}")
+        executor = getattr(self.worker, method)
         return executor(*args, **kwargs)
     
 class RPyCWorkerClient:

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -111,9 +111,9 @@ class RPyCWorkerService(rpyc.Service):
         print(os.getpid(), "starthead", time.time())
         args, kwargs = obtain(args), obtain(kwargs)
         executor = getattr(self.worker, method)
-        #print(os.getpid(), "startexec", time.time())
+        print(os.getpid(), "startexec", time.time())
         retval = executor(*args, **kwargs)
-        #print(os.getpid(), "stopexec", time.time())
+        print(os.getpid(), "stopexec", time.time())
         return retval
     
 class RPyCWorkerClient:
@@ -161,8 +161,9 @@ class RPyCWorkerClient:
         self._init_worker(model_config, parallel_config, scheduler_config)
 
     def execute_method(self, method, *args, **kwargs):
-        print(f"executing method {method} at {time.time()}")  # with threadpoolexecutor these seem to execute at the same time
+        print(f"executing method {method} at {time.time()}")  # with threadpoolexecutor these prints seem to execute at the same time
         ans = self._execute_method(method, *args, **kwargs)  # TODO is this right?
+        print(f"finish executing method {method} at {time.time()}")
         new_ans = obtain(ans)
         return new_ans
     

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -108,9 +108,12 @@ class RPyCWorkerService(rpyc.Service):
     def exposed_execute_method(self, method: str, *args, **kwargs):
         # print(f"execute_method running on {os.getpid()}")
         # print(type(self.worker))
+        print(os.getpid(), "starthead", time.time())
         args, kwargs = obtain(args), obtain(kwargs)
         executor = getattr(self.worker, method)
+        #print(os.getpid(), "startexec", time.time())
         retval = executor(*args, **kwargs)
+        #print(os.getpid(), "stopexec", time.time())
         return retval
     
 class RPyCWorkerClient:
@@ -158,14 +161,17 @@ class RPyCWorkerClient:
         self._init_worker(model_config, parallel_config, scheduler_config)
 
     def execute_method(self, method, *args, **kwargs):
-        print(f"executing method {method}")
-        return self._execute_method(method, *args, **kwargs)  # TODO is this right?
+        print(f"executing method {method} at {time.time()}")  # with threadpoolexecutor these seem to execute at the same time
+        ans = self._execute_method(method, *args, **kwargs)  # TODO is this right?
+        new_ans = obtain(ans)
+        return new_ans
     
     def get_addr_and_port(self):
         return self._get_addr_and_port()
     
     async def aexecute_method(self, method, *args, **kwargs):
-        # t1 = time.time()
+        t1 = time.time()
+        print(f'started at {t1}')
         ans = await self._aexecute_method(method, *args, **kwargs)
         # t2 = time.time()
         new_ans = obtain(ans)  # seems fast enough

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -108,12 +108,13 @@ class RPyCWorkerService(rpyc.Service):
     def exposed_execute_method(self, method: str, *args, **kwargs):
         # print(f"execute_method running on {os.getpid()}")
         # raise ValueError("crashing to view call stack")
-        # print(os.getpid(), "starthead", time.time())
-        args, kwargs = obtain(args), obtain(kwargs)  # is this thing slow?
+        print(os.getpid(), "starthead", time.time())
+        # I believe this obtain() makes a call to the other process, which may be a bottleneck. 
+        args, kwargs = obtain(args), obtain(kwargs)  # with prints, seems like this takes about 0.0025 seconds 4 workers n=1
         executor = getattr(self.worker, method)
-        # print(os.getpid(), "startexec", time.time())
+        print(os.getpid(), "startexec", time.time())
         retval = executor(*args, **kwargs)
-        # print(os.getpid(), "stopexec", time.time())
+        print(os.getpid(), "stopexec", time.time())
         return retval
     
 class RPyCWorkerClient:
@@ -175,7 +176,7 @@ class RPyCWorkerClient:
     
     async def aexecute_method(self, method, *args, **kwargs):
         t1 = time.time()
-        # print(f'started at {t1}')
+        print(f'started at {t1}')
         ans = await self._aexecute_method(method, *args, **kwargs)
         # t2 = time.time()
         new_ans = obtain(ans)  # seems fast enough

--- a/vllm/engine/rpyc_utils.py
+++ b/vllm/engine/rpyc_utils.py
@@ -108,6 +108,7 @@ class RPyCWorkerService(rpyc.Service):
     def exposed_execute_method(self, method: str, *args, **kwargs):
         print(f"execute_method running on {os.getpid()}")
         print(type(self.worker))
+        args, kwargs = obtain(args), obtain(kwargs)
         executor = getattr(self.worker, method)
         return executor(*args, **kwargs)
     
@@ -175,7 +176,11 @@ class RPyCWorkerClient:
 
 def init_rpyc_env(port):
     print(f"init_rpyc_env for port {port}")
+    print(os.getpid(), "importing torch", time.time())
+    # We need to import torch here, otherwise torch won't recognize CUDA devices as available.
+    # Not sure why unfortunately, but I think it's related to some ordering of imports/environment set up
     import torch
+    print(os.getpid(), "done importing torch", time.time())
     print("init_rpyc_env cuda support:", torch.cuda.is_available(),":", torch.cuda.device_count(), "devices")
     t = ThreadedServer(RPyCWorkerService(), port=port, protocol_config={"allow_pickle": True})
     t.start()

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -277,7 +277,7 @@ class Worker:
         blocks_to_copy: Dict[int, List[int]],
     ) -> SamplerOutput:
         st = time.time()  # doesn't seem to change when we swap ray for rpyc
-        print(f"st {os.getpid()} {st}")  # the execute_models() do not start at the same time
+        # print(f"st {os.getpid()} {st}")  # the execute_models() do not start at the same time
         # Issue cache operations.
         issued_cache_op = False
         if blocks_to_swap_in:
@@ -315,8 +315,8 @@ class Worker:
             cache_events=cache_events,
         )
         en = time.time()
-        print(f"en {os.getpid()} {en}")
-        print(f"execute_model time: {en - st}, pid {os.getpid()}")
+        # print(f"en {os.getpid()} {en}")
+        # print(f"execute_model time: {en - st}, pid {os.getpid()}")
         return output
 
 

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -46,6 +46,9 @@ class Worker:
         self.cache_events = None
         self.gpu_cache = None
 
+        # print(os.environ)
+
+
     def init_model(self):
         # This env var set by Ray causes exceptions with graph building.
         os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -277,7 +277,7 @@ class Worker:
         blocks_to_copy: Dict[int, List[int]],
     ) -> SamplerOutput:
         st = time.time()  # doesn't seem to change when we swap ray for rpyc
-        # print(f"st {os.getpid()} {st}")  # the execute_models() do not start at the same time
+        print(f"st {os.getpid()} {st}")  # the execute_models() do not start at the same time
         # Issue cache operations.
         issued_cache_op = False
         if blocks_to_swap_in:
@@ -315,8 +315,8 @@ class Worker:
             cache_events=cache_events,
         )
         en = time.time()
-        # print(f"en {os.getpid()} {en}")
-        # print(f"execute_model time: {en - st}, pid {os.getpid()}")
+        print(f"en {os.getpid()} {en}")
+        print(f"execute_model time: {en - st}, pid {os.getpid()}")
         return output
 
 

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -277,7 +277,7 @@ class Worker:
         blocks_to_copy: Dict[int, List[int]],
     ) -> SamplerOutput:
         st = time.time()  # doesn't seem to change when we swap ray for rpyc
-        print(f"st {os.getpid()} {st}")  # the execute_models() do not start at the same time
+        # print(f"st {os.getpid()} {st}")  # the execute_models() do not start at the same time
         # Issue cache operations.
         issued_cache_op = False
         if blocks_to_swap_in:
@@ -315,7 +315,7 @@ class Worker:
             cache_events=cache_events,
         )
         en = time.time()
-        print(f"en {os.getpid()} {en}")
+        # print(f"en {os.getpid()} {en}")
         print(f"execute_model time: {en - st}, pid {os.getpid()}")
         return output
 

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -328,6 +328,7 @@ def _init_distributed_environment(
             "distributed_init_method must be set if torch.distributed "
             "is not already initialized")
     else:
+        # todo maybe manually init?
         torch.distributed.init_process_group(
             backend="nccl",
             world_size=parallel_config.world_size,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -48,9 +48,6 @@ class Worker:
         self.cache_events = None
         self.gpu_cache = None
 
-        # print(os.environ)
-
-
     def init_model(self):
         # This env var set by Ray causes exceptions with graph building.
         os.environ.pop("NCCL_ASYNC_ERROR_HANDLING", None)
@@ -276,7 +273,7 @@ class Worker:
         blocks_to_swap_out: Dict[int, int],
         blocks_to_copy: Dict[int, List[int]],
     ) -> SamplerOutput:
-        st = time.time()  # doesn't seem to change when we swap ray for rpyc
+        # st = time.time()  # doesn't seem to change when we swap ray for rpyc
         # print(f"st {os.getpid()} {st}")  # the execute_models() do not start at the same time
         # Issue cache operations.
         issued_cache_op = False
@@ -305,7 +302,7 @@ class Worker:
         # Prepare input tensors.
         input_tokens, input_positions, input_metadata = self._prepare_inputs(
             seq_group_metadata_list)
-        med = time.time()
+        # med = time.time()
         # Execute the model.
         output = self.model(
             input_ids=input_tokens,
@@ -314,9 +311,9 @@ class Worker:
             input_metadata=input_metadata,
             cache_events=cache_events,
         )
-        en = time.time()
+        # en = time.time()
         # print(f"en {os.getpid()} {en}")
-        print(f"execute_model time: {en - st}, prep inputs: {med - st}, model forward: {en - med}, pid {os.getpid()}")
+        # print(f"execute_model time: {en - st}, prep inputs: {med - st}, model forward: {en - med}, pid {os.getpid()}")
         return output
 
 
@@ -338,7 +335,6 @@ def _init_distributed_environment(
             "distributed_init_method must be set if torch.distributed "
             "is not already initialized")
     else:
-        # todo maybe manually init?
         torch.distributed.init_process_group(
             backend="nccl",
             world_size=parallel_config.world_size,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -298,7 +298,7 @@ class Worker:
         # Prepare input tensors.
         input_tokens, input_positions, input_metadata = self._prepare_inputs(
             seq_group_metadata_list)
-        
+
         # Execute the model.
         output = self.model(
             input_ids=input_tokens,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -298,6 +298,8 @@ class Worker:
         # Prepare input tensors.
         input_tokens, input_positions, input_metadata = self._prepare_inputs(
             seq_group_metadata_list)
+        
+        # Execute the model.
         output = self.model(
             input_ids=input_tokens,
             positions=input_positions,

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -305,7 +305,7 @@ class Worker:
         # Prepare input tensors.
         input_tokens, input_positions, input_metadata = self._prepare_inputs(
             seq_group_metadata_list)
-
+        med = time.time()
         # Execute the model.
         output = self.model(
             input_ids=input_tokens,
@@ -316,7 +316,7 @@ class Worker:
         )
         en = time.time()
         # print(f"en {os.getpid()} {en}")
-        print(f"execute_model time: {en - st}, pid {os.getpid()}")
+        print(f"execute_model time: {en - st}, prep inputs: {med - st}, model forward: {en - med}, pid {os.getpid()}")
         return output
 
 

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -15,8 +15,6 @@ from vllm.sequence import SamplerOutput, SequenceData, SequenceGroupMetadata
 from vllm.worker.cache_engine import CacheEngine
 from vllm.utils import get_gpu_memory
 
-import time
-
 
 class Worker:
     """A worker class that executes (a partition of) the model on a GPU.
@@ -273,8 +271,6 @@ class Worker:
         blocks_to_swap_out: Dict[int, int],
         blocks_to_copy: Dict[int, List[int]],
     ) -> SamplerOutput:
-        # st = time.time()  # doesn't seem to change when we swap ray for rpyc
-        # print(f"st {os.getpid()} {st}")  # the execute_models() do not start at the same time
         # Issue cache operations.
         issued_cache_op = False
         if blocks_to_swap_in:
@@ -302,8 +298,6 @@ class Worker:
         # Prepare input tensors.
         input_tokens, input_positions, input_metadata = self._prepare_inputs(
             seq_group_metadata_list)
-        # med = time.time()
-        # Execute the model.
         output = self.model(
             input_ids=input_tokens,
             positions=input_positions,
@@ -311,9 +305,6 @@ class Worker:
             input_metadata=input_metadata,
             cache_events=cache_events,
         )
-        # en = time.time()
-        # print(f"en {os.getpid()} {en}")
-        # print(f"execute_model time: {en - st}, prep inputs: {med - st}, model forward: {en - med}, pid {os.getpid()}")
         return output
 
 

--- a/vllm/worker/worker.py
+++ b/vllm/worker/worker.py
@@ -15,6 +15,8 @@ from vllm.sequence import SamplerOutput, SequenceData, SequenceGroupMetadata
 from vllm.worker.cache_engine import CacheEngine
 from vllm.utils import get_gpu_memory
 
+import time
+
 
 class Worker:
     """A worker class that executes (a partition of) the model on a GPU.
@@ -274,6 +276,8 @@ class Worker:
         blocks_to_swap_out: Dict[int, int],
         blocks_to_copy: Dict[int, List[int]],
     ) -> SamplerOutput:
+        st = time.time()  # doesn't seem to change when we swap ray for rpyc
+        print(f"st {os.getpid()} {st}")  # the execute_models() do not start at the same time
         # Issue cache operations.
         issued_cache_op = False
         if blocks_to_swap_in:
@@ -310,6 +314,9 @@ class Worker:
             input_metadata=input_metadata,
             cache_events=cache_events,
         )
+        en = time.time()
+        print(f"en {os.getpid()} {en}")
+        print(f"execute_model time: {en - st}, pid {os.getpid()}")
         return output
 
 


### PR DESCRIPTION
- performance not as good as with ray, still a ways off in terms of overhead
- things I needed to do:
  - patch rpyc to use tcp nodelay
  - some "hacky" code, e.g. importing worker late, setting some env vars in weird places; to get the workers to launch
- things that I see as deficiencies in the rpyc approach:
  - from the timing, looks like serializing the data and sending it over to the worker processes incurs a significant overhead. Can try things like improve the serialization (e.g. not pickle/unpickle, but serialize to a json or something), or do some shared memory between processes.

Testing methodology:
Ran on a machine with 4xA10 GPUs. Ran the llama-2-7b chat model with tensor-parallel-size 4. Send a single request with a pretty short prompt and a pretty long response (e.g. ~5-10ish tokens prompt, asking for ~500-1000 tokens response).

Raw notes:

`curl http://localhost:8000/generate -d '{"prompt": "What is your name?", "n": 4, "temperature": 0.1}'`
`curl http://localhost:8000/generate -d '{"prompt": "How do you make cookies?", "n": 1, "temperature": 0.2, "max_tokens": 1024, "stream": false}'`

`python -m vllm.entrypoints.api_server --tensor-parallel-size 4 --model ~/llama-weights/hf-llama-2-7b-chat/`
`--worker-use-rpyc`

EOD 9/29:
llama-2-7b-chat, n=1:
17 tok/s with 4 workers, rpyc
53ish tok/s with 4 workers, ray
22 tok/s with 2 workers, rpyc
46 tok/s with 2 workers, ray

Midday 10/4
llama-2-7b-chat n=1:
49.5 tok/s with 4 workers, rpyc
54.7 tok/s with 4 workers, ray

~maybe something is set wrong for torch to make things super slow? profile execute_model and see what's up~

something with rpyc/some weird bottleneck in the python/processes/idk actually
(mostly) fixed via
```
--- a/rpyc/utils/factory.py
+++ b/rpyc/utils/factory.py
@@ -99,7 +99,7 @@ def connect(host, port, service=VoidService, config={}, ipv6=False, keepalive=Fa

     :returns: an RPyC connection
     """
-    s = SocketStream.connect(host, port, ipv6=ipv6, keepalive=keepalive)
+    s = SocketStream.connect(host, port, ipv6=ipv6, keepalive=keepalive, nodelay=True)
```

use asyncio vs threadpoolexec -> 49.5 tok/sec for rpyc vs 54.7 tok/sec for ray

~to investigate: something with model execute taking 0.025ish seconds vs 0.015 seconds on occasion~
maybe not a problem anymore? idk man my testing env might be not good?

TODO:
- replace obtain with deliver in the main process (kinda annoying, deliver doesn't work oob, need to investigate)
- continue adding prints in rpyc to figure out where bottleneck is (some gil thing, scheduling worker processes, something in the socket/connection itself???) (one big bottleneck in socket itself, fixed with tcp nodelay)
- read over ray code to see what they're doing differently (i.e. how remote() is implemented)
- read over lightllm to see if they're using rpyc in a way that avoids this issue
- see if you can get rpyc over pipes to work

```_run_workers_async start 1696448720.471795
_run_workers_async prep executors 1696448720.4718165
started at 1696448720.4718547
started at 1696448720.4719837
15871 starthead 1696448720.472019
started at 1696448720.472363
15872 starthead 1696448720.472397
15873 starthead 1696448720.4726086
started at 1696448720.4729712
15874 starthead 1696448720.4731753
15871 startexec 1696448720.4743671
15873 startexec 1696448720.4746091
15872 startexec 1696448720.475054
15874 startexec 1696448720.475109
execute_model time: 0.015847444534301758, prep inputs: 0.00012826919555664062, model forward: 0.015719175338745117, pid 15871
execute_model time: 0.015161752700805664, prep inputs: 0.00012612342834472656, model forward: 0.015035629272460938, pid 15872
15871 stopexec 1696448720.4902742
15872 stopexec 1696448720.4902766
execute_model time: 0.015143632888793945, prep inputs: 0.00013256072998046875, model forward: 0.015011072158813477, pid 15874
execute_model time: 0.01563858985900879, prep inputs: 0.00017571449279785156, model forward: 0.015462875366210938, pid 15873
15873 stopexec 1696448720.4903154
15874 stopexec 1696448720.4903169
_run_workers_async wait for gather, 1696448720.4921165
_run_workers_async end 1696448720.492134
_run_workers_async total 0.020339012145996094
_run_workers_async start 1696448720.4923127
_run_workers_async prep executors 1696448720.4923337
started at 1696448720.4923716
started at 1696448720.4925008
15871 starthead 1696448720.4925346
15872 starthead 1696448720.492742
started at 1696448720.492886
started at 1696448720.4930904
15873 starthead 1696448720.4931326
15874 starthead 1696448720.4934273
15871 startexec 1696448720.4946985
15872 startexec 1696448720.4953666
15873 startexec 1696448720.4956145
15874 startexec 1696448720.4958744
execute_model time: 0.01569080352783203, prep inputs: 0.00012826919555664062, model forward: 0.01556253433227539, pid 15872
execute_model time: 0.01636195182800293, prep inputs: 0.00014281272888183594, model forward: 0.016219139099121094, pid 15871
15872 stopexec 1696448720.5111196
15871 stopexec 1696448720.5111215
execute_model time: 0.015245199203491211, prep inputs: 0.00014734268188476562, model forward: 0.015097856521606445, pid 15874
execute_model time: 0.015501737594604492, prep inputs: 0.00017189979553222656, model forward: 0.015329837799072266, pid 15873
15873 stopexec 1696448720.5111866
15874 stopexec 1696448720.5111876
_run_workers_async wait for gather, 1696448720.5128732
_run_workers_async end 1696448720.5128915
_run_workers_async total 0.020578861236572266
```